### PR TITLE
feat: 订阅组流量节点开关、统一排序、缓存可视化、前缀独立开关与调试能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 .vscode
 # Misc
 .DS_Store
+.specstory/
+.cursorindexingignore

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -162,64 +162,82 @@ async function getStorageAdapter(env) {
 
 // --- [新] 默认设置中增加通知阈值和存储类型 ---
 const defaultSettings = {
-  FileName: 'MiSub',
-  mytoken: 'auto',
-  profileToken: 'profiles',
-  subConverter: 'url.v1.mk',
-  subConfig: 'https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/config/ACL4SSR_Online_Full.ini',
-  prependSubName: true,
-  NotifyThresholdDays: 3,
-  NotifyThresholdPercent: 90,
-  storageType: 'kv' // 新增：数据存储类型，默认 KV，可选 'd1'
+    FileName: 'MiSub',
+    mytoken: 'auto',
+    profileToken: 'profiles',
+    subConverter: 'url.v1.mk',
+    subConfig: 'https://raw.githubusercontent.com/cmliu/ACL4SSR/refs/heads/main/Clash/config/ACL4SSR_Online_Full.ini',
+    prependSubName: true, // 兼容旧字段
+    prependSubNameSubs: true, // 是否给机场订阅节点添加订阅名前缀
+    prependSubNameManual: false, // 是否给手动节点添加“手动节点”前缀
+    NotifyThresholdDays: 3,
+    NotifyThresholdPercent: 90,
+    storageType: 'kv', // 新增：数据存储类型，默认 KV，可选 'd1'
+    showTrafficRemainingNode: true, // 是否在聚合顶部插入“流量剩余”虚拟节点
+    // manualNodesPosition: 已废弃，由统一排序控制
 };
 
 const formatBytes = (bytes, decimals = 2) => {
-  if (!+bytes || bytes < 0) return '0 B';
-  const k = 1024;
-  const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
-  // toFixed(dm) after dividing by pow(k, i) was producing large decimal numbers
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  if (i < 0) return '0 B'; // Handle log(0) case
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+    if (!+bytes || bytes < 0) return '0 B';
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    // toFixed(dm) after dividing by pow(k, i) was producing large decimal numbers
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    if (i < 0) return '0 B'; // Handle log(0) case
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 };
+
+// 安全解碼：優先嘗試將 Base64 內容按 UTF-8 轉為純文本，否則原樣返回
+function decodeMaybeBase64ToUtf8(input) {
+    try {
+        const cleaned = input.replace(/\s/g, '');
+        if (cleaned.length > 20 && /^[A-Za-z0-9+/=]+$/.test(cleaned)) {
+            const binaryString = atob(cleaned);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) { bytes[i] = binaryString.charCodeAt(i); }
+            return new TextDecoder('utf-8').decode(bytes);
+        }
+    } catch { }
+    return input;
+}
 
 // --- TG 通知函式 (无修改) ---
 async function sendTgNotification(settings, message) {
-  if (!settings.BotToken || !settings.ChatID) {
-    console.log("TG BotToken or ChatID not set, skipping notification.");
-    return false;
-  }
-  // 为所有消息添加时间戳
-  const now = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
-  const fullMessage = `${message}\n\n*时间:* \`${now} (UTC+8)\``;
-  
-  const url = `https://api.telegram.org/bot${settings.BotToken}/sendMessage`;
-  const payload = { 
-    chat_id: settings.ChatID, 
-    text: fullMessage, 
-    parse_mode: 'Markdown',
-    disable_web_page_preview: true // 禁用链接预览，使消息更紧凑
-  };
-  
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    });
-    if (response.ok) {
-      console.log("TG 通知已成功发送。");
-      return true;
-    } else {
-      const errorData = await response.json();
-      console.error("发送 TG 通知失败：", response.status, errorData);
-      return false;
+    if (!settings.BotToken || !settings.ChatID) {
+        console.log("TG BotToken or ChatID not set, skipping notification.");
+        return false;
     }
-  } catch (error) {
-    console.error("发送 TG 通知时出错：", error);
-    return false;
-  }
+    // 为所有消息添加时间戳
+    const now = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
+    const fullMessage = `${message}\n\n*时间:* \`${now} (UTC+8)\``;
+
+    const url = `https://api.telegram.org/bot${settings.BotToken}/sendMessage`;
+    const payload = {
+        chat_id: settings.ChatID,
+        text: fullMessage,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true // 禁用链接预览，使消息更紧凑
+    };
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        if (response.ok) {
+            console.log("TG 通知已成功发送。");
+            return true;
+        } else {
+            const errorData = await response.json();
+            console.error("发送 TG 通知失败：", response.status, errorData);
+            return false;
+        }
+    } catch (error) {
+        console.error("发送 TG 通知时出错：", error);
+        return false;
+    }
 }
 
 async function handleCronTrigger(env) {
@@ -235,20 +253,20 @@ async function handleCronTrigger(env) {
         if (sub.url.startsWith('http') && sub.enabled) {
             try {
                 // --- 並行請求流量和節點內容 ---
-                const trafficRequest = fetch(new Request(sub.url, { 
-                    headers: { 'User-Agent': 'Clash for Windows/0.20.39' }, 
+                const trafficRequest = fetch(new Request(sub.url, {
+                    headers: { 'User-Agent': 'Clash for Windows/0.20.39' },
                     redirect: "follow",
-                    cf: { insecureSkipVerify: true } 
+                    cf: { insecureSkipVerify: true }
                 }));
-                const nodeCountRequest = fetch(new Request(sub.url, { 
-                    headers: { 'User-Agent': 'MiSub-Cron-Updater/1.0' }, 
+                const nodeCountRequest = fetch(new Request(sub.url, {
+                    headers: { 'User-Agent': 'MiSub-Cron-Updater/1.0' },
                     redirect: "follow",
-                    cf: { insecureSkipVerify: true } 
+                    cf: { insecureSkipVerify: true }
                 }));
                 const [trafficResult, nodeCountResult] = await Promise.allSettled([
                     Promise.race([trafficRequest, new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 8000))]),
                     Promise.race([nodeCountRequest, new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 8000))])
-                ]);   
+                ]);
 
                 if (trafficResult.status === 'fulfilled' && trafficResult.value.ok) {
                     const userInfoHeader = trafficResult.value.headers.get('subscription-userinfo');
@@ -263,17 +281,17 @@ async function handleCronTrigger(env) {
                         changesMade = true;
                     }
                 } else if (trafficResult.status === 'rejected') {
-                     console.error(`Cron: Failed to fetch traffic for ${sub.name}:`, trafficResult.reason.message);
+                    console.error(`Cron: Failed to fetch traffic for ${sub.name}:`, trafficResult.reason.message);
                 }
 
                 if (nodeCountResult.status === 'fulfilled' && nodeCountResult.value.ok) {
                     const text = await nodeCountResult.value.text();
                     let decoded = '';
-                    try { 
+                    try {
                         // 嘗試 Base64 解碼
-                        decoded = atob(text.replace(/\s/g, '')); 
-                    } catch { 
-                        decoded = text; 
+                        decoded = atob(text.replace(/\s/g, ''));
+                    } catch {
+                        decoded = text;
                     }
                     const matches = decoded.match(nodeRegex);
                     if (matches) {
@@ -284,7 +302,7 @@ async function handleCronTrigger(env) {
                     console.error(`Cron: Failed to fetch node list for ${sub.name}:`, nodeCountResult.reason.message);
                 }
 
-            } catch(e) {
+            } catch (e) {
                 console.error(`Cron: Unhandled error while updating ${sub.name}`, e.message);
             }
         }
@@ -340,7 +358,7 @@ async function checkAndNotify(sub, settings, env) {
     if (sub.userInfo.expire) {
         const expiryDate = new Date(sub.userInfo.expire * 1000);
         const daysRemaining = Math.ceil((expiryDate - now) / ONE_DAY_MS);
-        
+
         // 检查是否满足通知条件：剩余天数 <= 阈值
         if (daysRemaining <= (settings.NotifyThresholdDays || 7)) {
             // 检查上次通知时间，防止24小时内重复通知
@@ -371,7 +389,7 @@ async function checkAndNotify(sub, settings, env) {
                     const i = Math.floor(Math.log(bytes) / Math.log(k));
                     return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
                 };
-                
+
                 const message = `📈 *流量预警提醒* 📈\n\n*订阅名称:* \`${sub.name || '未命名'}\`\n*状态:* \`已使用 ${usagePercent}%\`\n*详情:* \`${formatBytes(used)} / ${formatBytes(total)}\``;
                 const sent = await sendTgNotification(settings, message);
                 if (sent) {
@@ -439,7 +457,7 @@ async function handleApiRequest(request, env) {
             if (!oldData) {
                 return new Response(JSON.stringify({ success: false, message: '未找到需要迁移的旧数据。' }), { status: 404 });
             }
-            
+
             await env.MISUB_KV.put(KV_KEY_SUBS, JSON.stringify(oldData));
             await env.MISUB_KV.put(KV_KEY_PROFILES, JSON.stringify([]));
             await env.MISUB_KV.put(OLD_KV_KEY + '_migrated_on_' + new Date().toISOString(), JSON.stringify(oldData));
@@ -478,7 +496,7 @@ async function handleApiRequest(request, env) {
             headers.append('Set-Cookie', `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0`);
             return new Response(JSON.stringify({ success: true }), { headers });
         }
-        
+
         case '/data': {
             try {
                 const storageAdapter = await getStorageAdapter(env);
@@ -493,7 +511,7 @@ async function handleApiRequest(request, env) {
                     profileToken: settings.profileToken || 'profiles'
                 };
                 return new Response(JSON.stringify({ misubs, profiles, config }), { headers: { 'Content-Type': 'application/json' } });
-            } catch(e) {
+            } catch (e) {
                 console.error('[API Error /data]', 'Failed to read from storage:', e);
                 return new Response(JSON.stringify({ error: '读取初始数据失败' }), { status: 500 });
             }
@@ -589,85 +607,104 @@ async function handleApiRequest(request, env) {
             }
         }
 
-            case '/node_count': {
-                if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
-                const { url: subUrl } = await request.json();
-                if (!subUrl || typeof subUrl !== 'string' || !/^https?:\/\//.test(subUrl)) {
-                    return new Response(JSON.stringify({ error: 'Invalid or missing url' }), { status: 400 });
-                }
-                
-                const result = { count: 0, userInfo: null };
+        case '/node_count': {
+            if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
+            const { url: subUrl, id: subId } = await request.json();
+            if (!subUrl || typeof subUrl !== 'string' || !/^https?:\/\//.test(subUrl)) {
+                return new Response(JSON.stringify({ error: 'Invalid or missing url' }), { status: 400 });
+            }
 
-                try {
-                    const fetchOptions = {
-                        headers: { 'User-Agent': 'MiSub-Node-Counter/2.0' },
-                        redirect: "follow",
-                        cf: { insecureSkipVerify: true }
-                    };
-                    const trafficFetchOptions = {
-                        headers: { 'User-Agent': 'Clash for Windows/0.20.39' },
-                        redirect: "follow",
-                        cf: { insecureSkipVerify: true }
-                    };
+            const result = { count: 0, userInfo: null };
+            let decodedText = null;
 
-                    const trafficRequest = fetch(new Request(subUrl, trafficFetchOptions));
-                    const nodeCountRequest = fetch(new Request(subUrl, fetchOptions));
+            try {
+                const fetchOptions = {
+                    headers: { 'User-Agent': 'MiSub-Node-Counter/2.0' },
+                    redirect: "follow",
+                    cf: { insecureSkipVerify: true }
+                };
+                const trafficFetchOptions = {
+                    headers: { 'User-Agent': 'Clash for Windows/0.20.39' },
+                    redirect: "follow",
+                    cf: { insecureSkipVerify: true }
+                };
 
-                    // --- [核心修正] 使用 Promise.allSettled 替换 Promise.all ---
-                    const responses = await Promise.allSettled([trafficRequest, nodeCountRequest]);
+                const trafficRequest = fetch(new Request(subUrl, trafficFetchOptions));
+                const nodeCountRequest = fetch(new Request(subUrl, fetchOptions));
 
-                    // 1. 处理流量请求的结果
-                    if (responses[0].status === 'fulfilled' && responses[0].value.ok) {
-                        const trafficResponse = responses[0].value;
-                        const userInfoHeader = trafficResponse.headers.get('subscription-userinfo');
-                        if (userInfoHeader) {
-                            const info = {};
-                            userInfoHeader.split(';').forEach(part => {
-                                const [key, value] = part.trim().split('=');
-                                if (key && value) info[key] = /^\d+$/.test(value) ? Number(value) : value;
-                            });
-                            result.userInfo = info;
-                        }
-                    } else if (responses[0].status === 'rejected') {
-                        console.error(`Traffic request for ${subUrl} rejected:`, responses[0].reason);
+                // --- [核心修正] 使用 Promise.allSettled 替换 Promise.all ---
+                const responses = await Promise.allSettled([trafficRequest, nodeCountRequest]);
+
+                // 1. 处理流量请求的结果
+                if (responses[0].status === 'fulfilled' && responses[0].value.ok) {
+                    const trafficResponse = responses[0].value;
+                    const userInfoHeader = trafficResponse.headers.get('subscription-userinfo');
+                    if (userInfoHeader) {
+                        const info = {};
+                        userInfoHeader.split(';').forEach(part => {
+                            const [key, value] = part.trim().split('=');
+                            if (key && value) info[key] = /^\d+$/.test(value) ? Number(value) : value;
+                        });
+                        result.userInfo = info;
                     }
+                } else if (responses[0].status === 'rejected') {
+                    console.error(`Traffic request for ${subUrl} rejected:`, responses[0].reason);
+                }
 
-                    // 2. 处理节点数请求的结果
-                    if (responses[1].status === 'fulfilled' && responses[1].value.ok) {
-                        const nodeCountResponse = responses[1].value;
-                        const text = await nodeCountResponse.text();
-                        let decoded = '';
-                        try { decoded = atob(text.replace(/\s/g, '')); } catch { decoded = text; }
-                        const lineMatches = decoded.match(/^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|anytls):\/\//gm);
-                        if (lineMatches) {
-                            result.count = lineMatches.length;
-                        }
-                    } else if (responses[1].status === 'rejected') {
+                // 2. 处理节点数请求的结果
+                if (responses[1].status === 'fulfilled' && responses[1].value.ok) {
+                    const nodeCountResponse = responses[1].value;
+                    const text = await nodeCountResponse.text();
+                    const decoded = decodeMaybeBase64ToUtf8(text);
+                    decodedText = decoded;
+                    result.cachedRaw = decodedText;
+                    const lineMatches = decoded.match(/^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|anytls):\/\//gm);
+                    if (lineMatches) {
+                        result.count = lineMatches.length;
+                    }
+                } else {
+                    // 包含兩種情況：請求被拒絕 或 響應非 2xx
+                    if (responses[1].status === 'rejected') {
                         console.error(`Node count request for ${subUrl} rejected:`, responses[1].reason);
                     }
-                    
-                    // {{ AURA-X: Modify - 使用存储适配器优化节点计数更新. Approval: 寸止(ID:1735459200). }}
-                    // 只有在至少获取到一个有效信息时，才更新数据库
-                    if (result.userInfo || result.count > 0) {
-                        const storageAdapter = await getStorageAdapter(env);
-                        const originalSubs = await storageAdapter.get(KV_KEY_SUBS) || [];
-                        const allSubs = JSON.parse(JSON.stringify(originalSubs)); // 深拷贝
-                        const subToUpdate = allSubs.find(s => s.url === subUrl);
-
-                        if (subToUpdate) {
-                            subToUpdate.nodeCount = result.count;
-                            subToUpdate.userInfo = result.userInfo;
-
-                            await storageAdapter.put(KV_KEY_SUBS, allSubs);
-                        }
-                    }
-                    
-                } catch (e) {
-                    console.error(`[API Error /node_count] Unhandled exception for URL: ${subUrl}`, e);
+                    // 將節點數視為 0，並清空緩存文本
+                    result.count = 0;
+                    decodedText = '';
+                    result.cachedRaw = '';
                 }
-                
-                return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+
+                // 始終更新：即使節點數為 0 或請求失敗，也更新 nodeCount 與緩存
+                const storageAdapter = await getStorageAdapter(env);
+                const originalSubs = await storageAdapter.get(KV_KEY_SUBS) || [];
+                const allSubs = JSON.parse(JSON.stringify(originalSubs)); // 深拷贝
+                let subToUpdate = null;
+                if (subId) {
+                    subToUpdate = allSubs.find(s => s.id === subId);
+                }
+                if (!subToUpdate) {
+                    subToUpdate = allSubs.find(s => s.url === subUrl);
+                }
+
+                if (subToUpdate) {
+                    subToUpdate.nodeCount = result.count;
+                    subToUpdate.userInfo = result.userInfo;
+                    subToUpdate.cachedRaw = typeof decodedText === 'string' ? decodedText : (subToUpdate.cachedRaw || '');
+                    subToUpdate.cachedAt = Date.now();
+                    subToUpdate.cachedFromUrl = subUrl;
+
+                    await storageAdapter.put(KV_KEY_SUBS, allSubs);
+
+                    // 回傳給前端用於 UI 顯示的緩存元信息
+                    result.cachedAt = subToUpdate.cachedAt;
+                    result.cachedRawPresent = !!(subToUpdate.cachedRaw && subToUpdate.cachedRaw.length > 0);
+                }
+
+            } catch (e) {
+                console.error(`[API Error /node_count] Unhandled exception for URL: ${subUrl}`, e);
             }
+
+            return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+        }
 
         case '/fetch_external_url': { // New case
             if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
@@ -743,15 +780,16 @@ async function handleApiRequest(request, env) {
 
                             // 更新节点数量
                             const text = await response.text();
-                            let decoded = '';
-                            try {
-                                decoded = atob(text.replace(/\s/g, ''));
-                            } catch {
-                                decoded = text;
-                            }
+                            const decoded = decodeMaybeBase64ToUtf8(text);
                             const nodeRegex = /^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|anytls|socks5):\/\//gm;
                             const matches = decoded.match(nodeRegex);
                             sub.nodeCount = matches ? matches.length : 0;
+                            // 保存原始解码后的订阅文本以供后续聚合使用
+                            if (decoded && decoded.length > 0) {
+                                sub.cachedRaw = decoded;
+                                sub.cachedAt = Date.now();
+                                sub.cachedFromUrl = sub.url;
+                            }
 
                             return { id: sub.id, success: true, nodeCount: sub.nodeCount };
                         } else {
@@ -820,171 +858,174 @@ async function handleApiRequest(request, env) {
             return new Response('Method Not Allowed', { status: 405 });
         }
     }
-    
+
     return new Response('API route not found', { status: 404 });
 }
 // --- 名称前缀辅助函数 (无修改) ---
 function prependNodeName(link, prefix) {
-  if (!prefix) return link;
-  const appendToFragment = (baseLink, namePrefix) => {
-    const hashIndex = baseLink.lastIndexOf('#');
-    const originalName = hashIndex !== -1 ? decodeURIComponent(baseLink.substring(hashIndex + 1)) : '';
-    const base = hashIndex !== -1 ? baseLink.substring(0, hashIndex) : baseLink;
-    if (originalName.startsWith(namePrefix)) {
-        return baseLink;
+    if (!prefix) return link;
+    const appendToFragment = (baseLink, namePrefix) => {
+        const hashIndex = baseLink.lastIndexOf('#');
+        const originalName = hashIndex !== -1 ? decodeURIComponent(baseLink.substring(hashIndex + 1)) : '';
+        const base = hashIndex !== -1 ? baseLink.substring(0, hashIndex) : baseLink;
+        if (originalName.startsWith(namePrefix)) {
+            return baseLink;
+        }
+        const newName = originalName ? `${namePrefix} - ${originalName}` : namePrefix;
+        return `${base}#${encodeURIComponent(newName)}`;
     }
-    const newName = originalName ? `${namePrefix} - ${originalName}` : namePrefix;
-    return `${base}#${encodeURIComponent(newName)}`;
-  }
-  if (link.startsWith('vmess://')) {
-    try {
-      const base64Part = link.substring('vmess://'.length);
-      const binaryString = atob(base64Part);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-      }
-      const jsonString = new TextDecoder('utf-8').decode(bytes);
-      const nodeConfig = JSON.parse(jsonString);
-      const originalPs = nodeConfig.ps || '';
-      if (!originalPs.startsWith(prefix)) {
-        nodeConfig.ps = originalPs ? `${prefix} - ${originalPs}` : prefix;
-      }
-      const newJsonString = JSON.stringify(nodeConfig);
-      const newBase64Part = btoa(unescape(encodeURIComponent(newJsonString)));
-      return 'vmess://' + newBase64Part;
-    } catch (e) {
-      console.error("为 vmess 节点添加名称前缀失败，将回退到通用方法。", e);
-      return appendToFragment(link, prefix);
+    if (link.startsWith('vmess://')) {
+        try {
+            const base64Part = link.substring('vmess://'.length);
+            const binaryString = atob(base64Part);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
+            }
+            const jsonString = new TextDecoder('utf-8').decode(bytes);
+            const nodeConfig = JSON.parse(jsonString);
+            const originalPs = nodeConfig.ps || '';
+            if (!originalPs.startsWith(prefix)) {
+                nodeConfig.ps = originalPs ? `${prefix} - ${originalPs}` : prefix;
+            }
+            const newJsonString = JSON.stringify(nodeConfig);
+            const newBase64Part = btoa(unescape(encodeURIComponent(newJsonString)));
+            return 'vmess://' + newBase64Part;
+        } catch (e) {
+            console.error("为 vmess 节点添加名称前缀失败，将回退到通用方法。", e);
+            return appendToFragment(link, prefix);
+        }
     }
-  }
-  return appendToFragment(link, prefix);
+    return appendToFragment(link, prefix);
 }
 
-// --- 节点列表生成函数 ---
-async function generateCombinedNodeList(context, config, userAgent, misubs, prependedContent = '') {
+// --- 节点列表生成函数（保留前端保存的顺序） ---
+async function generateCombinedNodeList(context, config, userAgent, misubs, prependedContent = '', debugCollector = null) {
     const nodeRegex = /^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|anytls|socks5):\/\//;
-    const processedManualNodes = misubs.filter(sub => !sub.url.toLowerCase().startsWith('http')).map(node => {
-        if (node.isExpiredNode) {
-            return node.url; // Directly use the URL for expired node
-        } else {
-            return (config.prependSubName) ? prependNodeName(node.url, '手动节点') : node.url;
+
+    // 逐项按保存顺序生成，HTTP 订阅并行请求但保持顺序
+    const itemTasks = misubs.map((item) => {
+        if (!item.url.toLowerCase().startsWith('http')) {
+            // 手动节点
+            const shouldPrefixManual = (typeof config.prependSubNameManual === 'boolean') ? config.prependSubNameManual : config.prependSubName;
+            return Promise.resolve(item.isExpiredNode ? item.url : (shouldPrefixManual ? prependNodeName(item.url, '手动节点') : item.url));
         }
-    }).join('\n');
-
-    const httpSubs = misubs.filter(sub => sub.url.toLowerCase().startsWith('http'));
-    const subPromises = httpSubs.map(async (sub) => {
-        try {
-            const requestHeaders = { 'User-Agent': userAgent };
-            const response = await Promise.race([
-                fetch(new Request(sub.url, { headers: requestHeaders, redirect: "follow", cf: { insecureSkipVerify: true } })),
-                new Promise((_, reject) => setTimeout(() => reject(new Error('Request timed out')), 10000))
-            ]);
-            if (!response.ok) return '';
-            let text = await response.text();
+        // 订阅
+        const sub = item;
+        return (async () => {
             try {
-                const cleanedText = text.replace(/\s/g, '');
-                if (cleanedText.length > 20 && /^[A-Za-z0-9+\/=]+$/.test(cleanedText)) {
-                    const binaryString = atob(cleanedText);
-                    const bytes = new Uint8Array(binaryString.length);
-                    for (let i = 0; i < binaryString.length; i++) { bytes[i] = binaryString.charCodeAt(i); }
-                    text = new TextDecoder('utf-8').decode(bytes);
-                }
-            } catch (e) {}
-            let validNodes = text.replace(/\r\n/g, '\n').split('\n')
-                .map(line => line.trim()).filter(line => nodeRegex.test(line));
-
-            // [核心重構] 引入白名單 (keep:) 和黑名單 (exclude) 模式
-            if (sub.exclude && sub.exclude.trim() !== '') {
-                const rules = sub.exclude.trim().split('\n').map(r => r.trim()).filter(Boolean);
-                
-                const keepRules = rules.filter(r => r.toLowerCase().startsWith('keep:'));
-
-                if (keepRules.length > 0) {
-                    // --- 白名單模式 (Inclusion Mode) ---
-                    const nameRegexParts = [];
-                    const protocolsToKeep = new Set();
-
-                    keepRules.forEach(rule => {
-                        const content = rule.substring('keep:'.length).trim();
-                        if (content.toLowerCase().startsWith('proto:')) {
-                            const protocols = content.substring('proto:'.length).split(',').map(p => p.trim().toLowerCase());
-                            protocols.forEach(p => protocolsToKeep.add(p));
-                        } else {
-                            nameRegexParts.push(content);
-                        }
-                    });
-
-                    const nameRegex = nameRegexParts.length > 0 ? new RegExp(nameRegexParts.join('|'), 'i') : null;
-                    
-                    validNodes = validNodes.filter(nodeLink => {
-                        // 檢查協議是否匹配
-                        const protocolMatch = nodeLink.match(/^(.*?):\/\//);
-                        const protocol = protocolMatch ? protocolMatch[1].toLowerCase() : '';
-                        if (protocolsToKeep.has(protocol)) {
-                            return true;
-                        }
-
-                        // 檢查名稱是否匹配
-                        if (nameRegex) {
-                            const hashIndex = nodeLink.lastIndexOf('#');
-                            if (hashIndex !== -1) {
-                                try {
-                                    const nodeName = decodeURIComponent(nodeLink.substring(hashIndex + 1));
-                                    if (nameRegex.test(nodeName)) {
-                                        return true;
-                                    }
-                                } catch (e) { /* 忽略解碼錯誤 */ }
-                            }
-                        }
-                        return false; // 白名單模式下，不匹配任何規則則排除
-                    });
-
+                let text = '';
+                let usedSource = 'cache';
+                if (sub.realtimeFetch === false) {
+                    text = sub.cachedRaw || '';
+                    if (!text) return '';
                 } else {
-                    // --- 黑名單模式 (Exclusion Mode) ---
-                    const protocolsToExclude = new Set();
-                    const nameRegexParts = [];
-
-                    rules.forEach(rule => {
-                        if (rule.toLowerCase().startsWith('proto:')) {
-                            const protocols = rule.substring('proto:'.length).split(',').map(p => p.trim().toLowerCase());
-                            protocols.forEach(p => protocolsToExclude.add(p));
-                        } else {
-                            nameRegexParts.push(rule);
+                    const requestHeaders = { 'User-Agent': userAgent };
+                    const response = await Promise.race([
+                        fetch(new Request(sub.url, { headers: requestHeaders, redirect: 'follow', cf: { insecureSkipVerify: true } })),
+                        new Promise((_, reject) => setTimeout(() => reject(new Error('Request timed out')), 10000))
+                    ]);
+                    if (!response.ok) {
+                        text = sub.cachedRaw || '';
+                        usedSource = 'cache';
+                        if (!text) return '';
+                    } else {
+                        text = await response.text();
+                        usedSource = 'live';
+                    }
+                    try {
+                        const cleanedText = text.replace(/\s/g, '');
+                        if (cleanedText.length > 20 && /^[A-Za-z0-9+\/=]+$/.test(cleanedText)) {
+                            const binaryString = atob(cleanedText);
+                            const bytes = new Uint8Array(binaryString.length);
+                            for (let i = 0; i < binaryString.length; i++) { bytes[i] = binaryString.charCodeAt(i); }
+                            text = new TextDecoder('utf-8').decode(bytes);
                         }
-                    });
-                    
-                    const nameRegex = nameRegexParts.length > 0 ? new RegExp(nameRegexParts.join('|'), 'i') : null;
+                    } catch (e) { }
+                }
+                let validNodes = text.replace(/\r\n/g, '\n').split('\n')
+                    .map(line => line.trim()).filter(line => nodeRegex.test(line));
 
-                    validNodes = validNodes.filter(nodeLink => {
-                        const protocolMatch = nodeLink.match(/^(.*?):\/\//);
-                        const protocol = protocolMatch ? protocolMatch[1].toLowerCase() : '';
-                        if (protocolsToExclude.has(protocol)) {
-                            return false;
-                        }
-
-                        if (nameRegex) {
-                            const hashIndex = nodeLink.lastIndexOf('#');
-                            if (hashIndex !== -1) {
-                                try {
-                                    const nodeName = decodeURIComponent(nodeLink.substring(hashIndex + 1));
-                                    if (nameRegex.test(nodeName)) {
-                                        return false;
-                                    }
-                                } catch (e) { /* 忽略解碼錯誤 */ }
+                // 保留过滤规则
+                if (sub.exclude && sub.exclude.trim() !== '') {
+                    const rules = sub.exclude.trim().split('\n').map(r => r.trim()).filter(Boolean);
+                    const keepRules = rules.filter(r => r.toLowerCase().startsWith('keep:'));
+                    if (keepRules.length > 0) {
+                        const nameRegexParts = [];
+                        const protocolsToKeep = new Set();
+                        keepRules.forEach(rule => {
+                            const content = rule.substring('keep:'.length).trim();
+                            if (content.toLowerCase().startsWith('proto:')) {
+                                const protocols = content.substring('proto:'.length).split(',').map(p => p.trim().toLowerCase());
+                                protocols.forEach(p => protocolsToKeep.add(p));
+                            } else {
+                                nameRegexParts.push(content);
                             }
-                        }
-                        return true;
+                        });
+                        const nameRegex = nameRegexParts.length > 0 ? new RegExp(nameRegexParts.join('|'), 'i') : null;
+                        validNodes = validNodes.filter(nodeLink => {
+                            const protocolMatch = nodeLink.match(/^(.*?):\/\//);
+                            const protocol = protocolMatch ? protocolMatch[1].toLowerCase() : '';
+                            if (protocolsToKeep.has(protocol)) return true;
+                            if (nameRegex) {
+                                const hashIndex = nodeLink.lastIndexOf('#');
+                                if (hashIndex !== -1) {
+                                    try {
+                                        const nodeName = decodeURIComponent(nodeLink.substring(hashIndex + 1));
+                                        if (nameRegex.test(nodeName)) return true;
+                                    } catch (e) { }
+                                }
+                            }
+                            return false;
+                        });
+                    } else {
+                        const protocolsToExclude = new Set();
+                        const nameRegexParts = [];
+                        rules.forEach(rule => {
+                            if (rule.toLowerCase().startsWith('proto:')) {
+                                const protocols = rule.substring('proto:'.length).split(',').map(p => p.trim().toLowerCase());
+                                protocols.forEach(p => protocolsToExclude.add(p));
+                            } else { nameRegexParts.push(rule); }
+                        });
+                        const nameRegex = nameRegexParts.length > 0 ? new RegExp(nameRegexParts.join('|'), 'i') : null;
+                        validNodes = validNodes.filter(nodeLink => {
+                            const protocolMatch = nodeLink.match(/^(.*?):\/\//);
+                            const protocol = protocolMatch ? protocolMatch[1].toLowerCase() : '';
+                            if (protocolsToExclude.has(protocol)) return false;
+                            if (nameRegex) {
+                                const hashIndex = nodeLink.lastIndexOf('#');
+                                if (hashIndex !== -1) {
+                                    try {
+                                        const nodeName = decodeURIComponent(nodeLink.substring(hashIndex + 1));
+                                        if (nameRegex.test(nodeName)) return false;
+                                    } catch (e) { }
+                                }
+                            }
+                            return true;
+                        });
+                    }
+                }
+
+                const shouldPrefixSubs = (typeof config.prependSubNameSubs === 'boolean') ? config.prependSubNameSubs : config.prependSubName;
+                const output = (shouldPrefixSubs && sub.name)
+                    ? validNodes.map(node => prependNodeName(node, sub.name)).join('\n')
+                    : validNodes.join('\n');
+                if (debugCollector) {
+                    debugCollector.push({
+                        id: sub.id,
+                        name: sub.name || '',
+                        realtimeFetch: sub.realtimeFetch !== false,
+                        usedSource,
+                        inputCount: (text.replace(/\r\n/g, '\n').split('\n').map(l => l.trim()).filter(l => nodeRegex.test(l))).length,
+                        outputCount: validNodes.length
                     });
                 }
-            }
-            return (config.prependSubName && sub.name)
-                ? validNodes.map(node => prependNodeName(node, sub.name)).join('\n')
-                : validNodes.join('\n');
-        } catch (e) { return ''; }
+                return output;
+            } catch { return ''; }
+        })();
     });
-    const processedSubContents = await Promise.all(subPromises);
-    const combinedContent = (processedManualNodes + '\n' + processedSubContents.join('\n'));
+    const pieces = await Promise.all(itemTasks);
+    const combinedContent = pieces.join('\n');
     const uniqueNodesString = [...new Set(combinedContent.split('\n').map(line => line.trim()).filter(line => line))].join('\n');
 
     // 确保最终的字符串在非空时以换行符结束，以兼容 subconverter
@@ -1017,7 +1058,7 @@ async function handleMisubRequest(context) {
     const allMisubs = misubsData || [];
     const allProfiles = profilesData || [];
     // 關鍵：我們在這裡定義了 `config`，後續都應該使用它
-    const config = { ...defaultSettings, ...settings }; 
+    const config = { ...defaultSettings, ...settings };
 
     let token = '';
     let profileIdentifier = null;
@@ -1097,7 +1138,7 @@ async function handleMisubRequest(context) {
     if (!effectiveSubConverter || effectiveSubConverter.trim() === '') {
         return new Response('Subconverter backend is not configured.', { status: 500 });
     }
-    
+
     let targetFormat = url.searchParams.get('target');
     if (!targetFormat) {
         const supportedFormats = ['clash', 'singbox', 'surge', 'loon', 'base64', 'v2ray', 'trojan'];
@@ -1118,7 +1159,7 @@ async function handleMisubRequest(context) {
             ['clash.meta', 'clash'],
             ['clash-verge', 'clash'],
             ['meta', 'clash'],
-            
+
             // 其他客戶端
             ['stash', 'clash'],
             ['nekoray', 'clash'],
@@ -1149,7 +1190,7 @@ async function handleMisubRequest(context) {
         const country = request.headers.get('CF-IPCountry') || 'N/A';
         const domain = url.hostname;
         let message = `🛰️ *订阅被访问* 🛰️\n\n*域名:* \`${domain}\`\n*客户端:* \`${userAgentHeader}\`\n*IP 地址:* \`${clientIp} (${country})\`\n*请求格式:* \`${targetFormat}\``;
-        
+
         if (profileIdentifier) {
             message += `\n*订阅组:* \`${subName}\``;
             const profile = allProfiles.find(p => (p.customId && p.customId === profileIdentifier) || p.id === profileIdentifier);
@@ -1158,7 +1199,7 @@ async function handleMisubRequest(context) {
                 message += `\n*到期时间:* \`${expiryDateStr}\``;
             }
         }
-        
+
         context.waitUntil(sendTgNotification(config, message));
     }
 
@@ -1166,7 +1207,13 @@ async function handleMisubRequest(context) {
 
     if (isProfileExpired) { // Use the flag set earlier
         prependedContentForSubconverter = ''; // Expired node is now in targetMisubs
-    } else {
+    } else if (((() => {
+        if (profileIdentifier) {
+            const pf = allProfiles.find(p => (p.customId && p.customId === profileIdentifier) || p.id === profileIdentifier);
+            if (pf && pf.showTrafficRemainingNode === false) return false;
+        }
+        return config.showTrafficRemainingNode !== false;
+    })())) {
         // Otherwise, add traffic remaining info if applicable
         const totalRemainingBytes = targetMisubs.reduce((acc, sub) => {
             if (sub.enabled && sub.userInfo && sub.userInfo.total > 0) {
@@ -1183,7 +1230,27 @@ async function handleMisubRequest(context) {
         }
     }
 
-    const combinedNodeList = await generateCombinedNodeList(context, config, userAgentHeader, targetMisubs, prependedContentForSubconverter);
+    const debugMode = url.searchParams.has('__debug');
+    const debugCollector = debugMode ? [] : null;
+    const combinedNodeList = await generateCombinedNodeList(context, config, userAgentHeader, targetMisubs, prependedContentForSubconverter, debugCollector);
+
+    if (debugMode) {
+        // 直接返回純文本，包含調試信息與最終節點列表
+        const lines = [];
+        lines.push('# MiSub Debug Report');
+        lines.push(`Target: ${profileIdentifier ? 'profile' : 'default'}`);
+        lines.push(`Items: ${targetMisubs.length}`);
+        if (debugCollector) {
+            debugCollector.forEach(d => {
+                lines.push(`- ${d.name || d.id}: source=${d.usedSource}${d.realtimeFetch ? '(live-on)' : '(live-off)'} input=${d.inputCount} output=${d.outputCount}`);
+            });
+        }
+        lines.push('');
+        lines.push('--- Combined Nodes ---');
+        lines.push(combinedNodeList);
+        const headers = { "Content-Type": "text/plain; charset=utf-8", 'Cache-Control': 'no-store, no-cache' };
+        return new Response(lines.join('\n'), { headers });
+    }
 
     if (targetFormat === 'base64') {
         let contentToEncode;
@@ -1205,7 +1272,7 @@ async function handleMisubRequest(context) {
         const headers = { "Content-Type": "text/plain; charset=utf-8", 'Cache-Control': 'no-store, no-cache' };
         return new Response(base64Content, { headers });
     }
-    
+
     const subconverterUrl = new URL(`https://${effectiveSubConverter}/sub`);
     subconverterUrl.searchParams.set('target', targetFormat);
     subconverterUrl.searchParams.set('url', callbackUrl);
@@ -1213,7 +1280,7 @@ async function handleMisubRequest(context) {
         subconverterUrl.searchParams.set('config', effectiveSubConfig);
     }
     subconverterUrl.searchParams.set('new_name', 'true');
-    
+
     try {
         const subconverterResponse = await fetch(subconverterUrl.toString(), {
             method: 'GET',

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import Modal from './Modal.vue';
 
 const props = defineProps({
   misub: {
@@ -87,6 +88,48 @@ const expiryInfo = computed(() => {
         style: style
     };
 });
+
+const showCacheModal = ref(false);
+function decodeMaybeBase64ToUtf8(input) {
+  try {
+    const cleaned = input.replace(/\s/g, '');
+    if (cleaned.length > 20 && /^[A-Za-z0-9+/=]+$/.test(cleaned)) {
+      const binaryString = atob(cleaned);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
+      return new TextDecoder('utf-8').decode(bytes);
+    }
+  } catch {}
+  return input;
+}
+
+const cachePreview = computed(() => {
+  const raw = props.misub.cachedRaw || '';
+  if (!raw) return '';
+  const decoded = decodeMaybeBase64ToUtf8(raw);
+  return decoded.length > 2000 ? decoded.slice(0, 2000) + '\n...（已截断）' : decoded;
+});
+
+const cachedLinesCount = computed(() => {
+  const raw = props.misub.cachedRaw || '';
+  const present = props.misub.cachedRawPresent ?? (raw && raw.length > 0);
+  if (!present) return null;
+  const decoded = decodeMaybeBase64ToUtf8(raw);
+  const nodeRegex = /^(ss|ssr|vmess|vless|trojan|hysteria2?|hy|hy2|tuic|anytls|socks5):\/\//m;
+  const count = decoded
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => nodeRegex.test(l)).length;
+  return count;
+});
+
+const copyCache = async () => {
+  try {
+    await navigator.clipboard.writeText(props.misub.cachedRaw || '');
+  } catch {}
+};
+
 </script>
 
 <template>
@@ -114,6 +157,13 @@ const expiryInfo = computed(() => {
     
     <div class="mt-2 grow flex flex-col justify-center space-y-2">
       <input type="text" :value="misub.url" readonly class="w-full text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800/50 rounded-lg px-3 py-2 focus:outline-hidden font-mono" />
+      <div class="flex items-center gap-2 mt-1 text-xs">
+        <span :class="(misub.cachedRawPresent ?? (misub.cachedRaw && misub.cachedRaw.length > 0)) ? 'text-green-600 dark:text-green-400' : 'text-gray-400'">
+          {{ (misub.cachedRawPresent ?? (misub.cachedRaw && misub.cachedRaw.length > 0)) ? '缓存可用' : '无缓存' }}
+        </span>
+        <span v-if="cachedLinesCount !== null" class="text-gray-400">· {{ cachedLinesCount }} 行</span>
+        <span v-if="misub.cachedAt" class="text-gray-400">· {{ new Date(misub.cachedAt).toLocaleString() }}</span>
+      </div>
       <div v-if="trafficInfo" class="space-y-1 pt-1">
         <div class="flex justify-between text-xs font-mono"><span class="text-gray-600 dark:text-gray-400">{{ trafficInfo.used }}</span><span class="text-gray-600 dark:text-gray-400">{{ trafficInfo.total }}</span></div>
         <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5"><div class="bg-linear-to-r from-blue-500 to-indigo-600 h-1.5 rounded-full" :style="{ width: trafficInfo.percentage + '%' }"></div></div>
@@ -121,17 +171,43 @@ const expiryInfo = computed(() => {
     </div>
 
     <div class="flex justify-between items-center mt-3">
-        <div class="flex items-center gap-2">
-          <label class="relative inline-flex items-center cursor-pointer">
-            <input type="checkbox" v-model="misub.enabled" @change="emit('change')" class="sr-only peer">
-            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-500 peer-checked:bg-indigo-600 dark:peer-checked:bg-green-600"></div>
-          </label>
+        <div class="flex items-center gap-4">
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-gray-500 dark:text-gray-400">启用</span>
+            <label class="relative inline-flex items-center cursor-pointer" title="启用/禁用此订阅">
+              <input type="checkbox" v-model="misub.enabled" @change="emit('change')" class="sr-only peer">
+              <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-500 peer-checked:bg-indigo-600 dark:peer-checked:bg-green-600"></div>
+            </label>
+          </div>
+          <div v-if="protocol === 'http' || protocol === 'https'" class="flex items-center gap-2">
+            <span class="text-xs text-gray-500 dark:text-gray-400">实时</span>
+            <label class="relative inline-flex items-center cursor-pointer" title="聚合访问时是否实时拉取上游">
+              <input type="checkbox" v-model="misub.realtimeFetch" @change="emit('change')" class="sr-only peer">
+              <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-500 peer-checked:bg-indigo-600 dark:peer-checked:bg-green-600"></div>
+            </label>
+          </div>
           <span v-if="expiryInfo" class="text-xs font-medium" :class="expiryInfo.style">{{ expiryInfo.daysRemaining }}</span>
         </div>
       <div class="flex items-center space-x-3">
         <span class="text-sm font-semibold" :class="misub.isUpdating ? 'text-yellow-500 animate-pulse' : 'text-gray-700 dark:text-gray-300'">{{ misub.isUpdating ? '更新中...' : `${misub.nodeCount} Nodes` }}</span>
         <button @click="emit('update')" :disabled="misub.isUpdating" class="text-gray-400 hover:text-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" title="更新节点数和流量"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" :class="{'animate-spin': misub.isUpdating}" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" /></svg></button>
+        <button @click="showCacheModal = true" :disabled="!(misub.cachedRawPresent ?? (misub.cachedRaw && misub.cachedRaw.length > 0))" class="text-gray-400 hover:text-indigo-500 transition-colors disabled:opacity-40" title="查看缓存"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5c-7.633 0-11 7-11 7s3.367 7 11 7 11-7 11-7-3.367-7-11-7zm0 12a5 5 0 110-10 5 5 0 010 10zm0-2a3 3 0 100-6 3 3 0 000 6z"/></svg></button>
       </div>
     </div>
+
+    <Modal v-model:show="showCacheModal" :size="'2xl'">
+      <template #title>
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-bold text-gray-900 dark:text-white">查看缓存</h3>
+          <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span>{{ misub.cachedAt ? new Date(misub.cachedAt).toLocaleString() : '无时间' }}</span>
+            <button class="px-2 py-1 rounded bg-gray-200 dark:bg-gray-700" @click="copyCache">复制</button>
+          </div>
+        </div>
+      </template>
+      <template #body>
+        <pre class="text-xs leading-5 whitespace-pre-wrap max-h-[60vh] overflow-auto bg-gray-50 dark:bg-gray-900/40 p-3 rounded">{{ cachePreview }}</pre>
+      </template>
+    </Modal>
   </div>
 </template>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -40,47 +40,49 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeydown));
 </script>
 
 <template>
-  <Transition name="modal-fade">
-    <div
-      v-if="show"
-      class="fixed inset-0 bg-black/60 backdrop-blur-xs z-99 flex items-center justify-center p-4"
-      @click="emit('update:show', false)"
-    >
-      <Transition name="modal-inner">
-        <div
-          v-if="show"
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full text-left ring-1 ring-black/5 dark:ring-white/10 flex flex-col max-h-[85vh]"
-          :class="{
-            'max-w-sm': size === 'sm',
-            'max-w-2xl': size === '2xl'
-          }"
-          @click.stop
-        >
-          <div class="p-6 pb-4 shrink-0">
-            <slot name="title">
-              <h3 class="text-lg font-bold text-gray-900 dark:text-white">确认操作</h3>
-            </slot>
-          </div>
-          
-          <div class="px-6 pb-6 grow overflow-y-auto">
-             <slot name="body">
-                <p class="text-sm text-gray-500 dark:text-gray-400">你确定要继续吗？</p>
-            </slot>
-          </div>
+  <teleport to="body">
+    <Transition name="modal-fade">
+      <div
+        v-if="show"
+        class="fixed inset-0 bg-black/60 backdrop-blur-xs z-[9999] flex items-center justify-center p-4"
+        @click="emit('update:show', false)"
+      >
+        <Transition name="modal-inner">
+          <div
+            v-if="show"
+            class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full text-left ring-1 ring-black/5 dark:ring-white/10 flex flex-col max-h-[85vh]"
+            :class="{
+              'max-w-sm': size === 'sm',
+              'max-w-2xl': size === '2xl'
+            }"
+            @click.stop
+          >
+            <div class="p-6 pb-4 shrink-0">
+              <slot name="title">
+                <h3 class="text-lg font-bold text-gray-900 dark:text-white">确认操作</h3>
+              </slot>
+            </div>
+            
+            <div class="px-6 pb-6 grow overflow-y-auto">
+               <slot name="body">
+                  <p class="text-sm text-gray-500 dark:text-gray-400">你确定要继续吗？</p>
+              </slot>
+            </div>
 
-          <div class="p-6 pt-4 flex justify-end space-x-3 shrink-0 border-t border-gray-200 dark:border-gray-700">
-            <button @click="emit('update:show', false)" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-semibold text-sm rounded-lg transition-colors">取消</button>
-            <button 
-                @click="handleConfirm" 
-                :disabled="confirmDisabled || (confirmKeyword && confirmInput !== confirmKeyword)"
-                :title="confirmDisabled ? confirmButtonTitle : '确认'"
-                class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm rounded-lg transition-colors disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:opacity-70 disabled:cursor-not-allowed"
-            >确认</button>
+            <div class="p-6 pt-4 flex justify-end space-x-3 shrink-0 border-t border-gray-200 dark:border-gray-700">
+              <button @click="emit('update:show', false)" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-semibold text-sm rounded-lg transition-colors">取消</button>
+              <button 
+                  @click="handleConfirm" 
+                  :disabled="confirmDisabled || (confirmKeyword && confirmInput !== confirmKeyword)"
+                  :title="confirmDisabled ? confirmButtonTitle : '确认'"
+                  class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm rounded-lg transition-colors disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:opacity-70 disabled:cursor-not-allowed"
+              >确认</button>
+            </div>
           </div>
-        </div>
-      </Transition>
-    </div>
-  </Transition>
+        </Transition>
+      </div>
+    </Transition>
+  </teleport>
 </template>
 
 <style scoped>

--- a/src/components/ProfileModal.vue
+++ b/src/components/ProfileModal.vue
@@ -132,9 +132,12 @@ watch(() => props.profile, (newProfile) => {
         profileCopy.expiresAt = '';
       }
     }
+    if (typeof profileCopy.showTrafficRemainingNode === 'undefined') {
+      profileCopy.showTrafficRemainingNode = true; // 默认显示，可在编辑中关闭
+    }
     localProfile.value = profileCopy;
   } else {
-    localProfile.value = { name: '', enabled: true, subscriptions: [], manualNodes: [], customId: '', expiresAt: '' };
+    localProfile.value = { name: '', enabled: true, subscriptions: [], manualNodes: [], customId: '', expiresAt: '', showTrafficRemainingNode: true };
   }
 }, { deep: true, immediate: true });
 
@@ -251,6 +254,18 @@ const handleDeselectAll = (listName, sourceArray) => {
               >
               <p class="text-xs text-gray-400 mt-1">设置此订阅组的到期时间，到期后将返回默认节点。</p>
             </div>
+        </div>
+
+        <!-- 订阅组作用域的“流量剩余”开关：放在列表上方，避免挤占两列布局 -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">显示“流量剩余”虚拟节点</label>
+          <div class="mt-2 flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+            <p class="text-sm text-gray-600 dark:text-gray-300">仅对该订阅组生效，覆盖全局设置</p>
+            <label class="relative inline-flex items-center cursor-pointer">
+              <input type="checkbox" v-model="localProfile.showTrafficRemainingNode" class="sr-only peer">
+              <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
+            </label>
+          </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -190,14 +190,34 @@ watch(() => props.show, (newValue) => {
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">节点名前缀</label>
+          <div class="mt-2 space-y-2">
+            <div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+              <p class="text-sm text-gray-600 dark:text-gray-300">为机场订阅的节点添加订阅名前缀</p>
+              <label class="relative inline-flex items-center cursor-pointer">
+                <input type="checkbox" v-model="settings.prependSubNameSubs" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+              <p class="text-sm text-gray-600 dark:text-gray-300">为手动节点添加“手动节点 - ”前缀</p>
+              <label class="relative inline-flex items-center cursor-pointer">
+                <input type="checkbox" v-model="settings.prependSubNameManual" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">显示“流量剩余”虚拟节点</label>
           <div class="mt-2 flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-            <p class="text-sm text-gray-600 dark:text-gray-300">自动将订阅名添加为节点名的前缀</p>
+            <p class="text-sm text-gray-600 dark:text-gray-300">关闭后将不再在顶部插入“流量剩余”节点</p>
             <label class="relative inline-flex items-center cursor-pointer">
-              <input type="checkbox" v-model="settings.prependSubName" class="sr-only peer">
+              <input type="checkbox" v-model="settings.showTrafficRemainingNode" class="sr-only peer">
               <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-600"></div>
             </label>
           </div>
         </div>
+        <!-- 移除“手动节点位置”设置，统一通过“统一排序”控制顺序，默认重置为“手动在前，订阅在后”。 -->
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">数据存储类型</label>
           <div class="space-y-3">

--- a/src/components/UnifiedSortModal.vue
+++ b/src/components/UnifiedSortModal.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { ref, watch } from 'vue';
+import draggable from 'vuedraggable';
+import Modal from './Modal.vue';
+
+const props = defineProps({
+  show: Boolean,
+  items: Array, // [{id, name, type}] type in {'sub','node'}
+  defaultItems: Array,
+});
+const emit = defineEmits(['update:show','confirm']);
+
+const localItems = ref([]);
+watch(() => props.show, (v) => { if (v) localItems.value = (props.items || []).map(i => ({...i})); });
+
+const handleConfirm = () => {
+  emit('confirm', localItems.value.map(i => i.id));
+  emit('update:show', false);
+};
+
+const handleReset = () => {
+  localItems.value = (props.defaultItems || []).map(i => ({ ...i }));
+};
+</script>
+
+<template>
+  <Modal :show="show" @update:show="emit('update:show', $event)" @confirm="handleConfirm" :size="'2xl'">
+    <template #title>
+      <div class="flex items-center justify-between w-full">
+        <h3 class="text-lg font-bold text-gray-800 dark:text-white">统一排序（订阅 + 手动节点）</h3>
+        <button type="button" @click="handleReset" class="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">重置</button>
+      </div>
+    </template>
+    <template #body>
+      <div class="text-xs text-gray-500 dark:text-gray-400 mb-3">拖拽以改变顺序（支持跨类别）。</div>
+      <draggable v-model="localItems" item-key="id" class="space-y-2" animation="250">
+        <template #item="{element}">
+          <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 ring-1 ring-black/5 dark:ring-white/10">
+            <div class="flex items-center gap-3">
+              <span class="text-[10px] px-2 py-0.5 rounded-full"
+                    :class="element.type==='sub' ? 'bg-indigo-500/20 text-indigo-600 dark:text-indigo-300' : 'bg-teal-500/20 text-teal-700 dark:text-teal-300'">
+                {{ element.type==='sub' ? '订阅' : '手动' }}
+              </span>
+              <span class="text-sm text-gray-700 dark:text-gray-200 truncate max-w-[60vw]">{{ element.name || (element.type==='sub' ? '未命名订阅' : '未命名节点') }}</span>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor"><path d="M7 4h6v2H7V4zm0 5h6v2H7V9zm0 5h6v2H7v-2z"/></svg>
+          </div>
+        </template>
+      </draggable>
+    </template>
+  </Modal>
+</template>
+
+

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -67,12 +67,12 @@ export async function saveMisubs(misubs, profiles) {
     }
 }
 
-export async function fetchNodeCount(subUrl) {
+export async function fetchNodeCount(subUrl, id) {
     try {
         const res = await fetch('/api/node_count', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: subUrl })
+            body: JSON.stringify({ url: subUrl, id })
         });
         const data = await res.json();
         return data; // [修正] 直接返回整个对象 { count, userInfo }


### PR DESCRIPTION
本 PR 主要完善分发与可运营性，聚焦“动态订阅可用性、排序一致性、可观测性”。
1、动机
解决某些机场只有动态订阅链接，链接有效期短，机场订阅链接过期后自动拉取订阅会导致聚合中该机场只有空内容问题
提升分享/分发场景的稳定性与可观测性，减少手工排障成本
2、主要改动
动态订阅兼容：保存机场节点订阅信息到缓存中，/api/node_count 成功/失败均回写状态；对于动态订阅机场，链接过期聚合失败回退使用缓存中保存的机场节点信息。
缓存可视化：卡片显示“缓存可用/无缓存 · 行数 · 最近更新时间”，并可查看缓存内容
订阅组：新增“显示‘流量剩余’虚拟节点”开关，优先于全局设置
统一排序：支持“订阅 + 手动节点”跨组拖拽，保存后聚合严格按保存顺序输出
名称前缀：拆分为“机场订阅节点前缀”与“手动节点前缀”两个开关
调试能力：聚合链接支持 debug，返回每个订阅的 live/cache 来源与节点计数
其它：小布局优化（Modal 层级/位置）、设置项说明补充
3、兼容性/迁移
兼容旧字段 prependSubName；新增 prependSubNameSubs / prependSubNameManual 有值时优先生效
已有数据无需迁移；若老环境无新字段，前端会填入合理默认值
4、测试与验证
本地与 Pages 环境自测：动态订阅过期场景下更新→缓存清空/节点数归0；聚合 fallback 生效
排序互通：面板与统一排序双向一致，以最后一次“保存更改”为准
订阅组差异化：自用组打开流量节点，分享组关闭，聚合输出符合预期
